### PR TITLE
Small text corrections

### DIFF
--- a/francedata/deputes/templates/deputes/depute_detail.html
+++ b/francedata/deputes/templates/deputes/depute_detail.html
@@ -16,7 +16,7 @@
         {% endif %}
         {% if depute.url_nosdeputes %}
         <li>
-            <a href="{{ depute.url_nosdeputes }}" title="{{ depute }} sur nodeputes.fr">Monitoring de l'abstentéisme de {{ depute }} sur nodeputes.fr</a>
+            <a href="{{ depute.url_nosdeputes }}" title="{{ depute }} sur nodeputes.fr">Monitoring de l'activité de {{ depute }} sur nodeputes.fr</a>
         </li>
         {% endif %}
         {% if depute.url_wikipedia %}

--- a/francedata/deputes/templates/deputes/depute_detail.html
+++ b/francedata/deputes/templates/deputes/depute_detail.html
@@ -11,7 +11,7 @@
     <ul>
         {% if depute.url_an %}
         <li>
-            <a href="{{ depute.url_an }}" title="{{ depute }} à l'Assemblée Nationale">{{ depute }} à l'Assemblée Nationale</a>
+            <a href="{{ depute.url_an }}" title="{{ depute }} à l'Assemblée nationale">{{ depute }} à l'Assemblée nationale</a>
         </li>
         {% endif %}
         {% if depute.url_nosdeputes %}


### PR DESCRIPTION
Please avoid limiting NosDéputés to "absentéïsme", the word vountarily does not appear anywhere on the website and it aims first at valorizing the actual vast activity of many.

Also there is normally no capital n to Assemblée nationale
